### PR TITLE
cleanly disconnect when server disconnects

### DIFF
--- a/Assets/Scripts/Control/Control.cs
+++ b/Assets/Scripts/Control/Control.cs
@@ -119,7 +119,7 @@ public class Control : ReplayableTCPClient<ControlMessage>
 
 	private void OutputErrorMessage()
 	{
-		print(name + " - connection failed (" + LastErrorMessage + ")");
+		print(name + " - connection lost (" + LastErrorMessage + ")");
 	}
 		
 	private ModuleState ModuleStateFromControlCommand(ControlCommands cmd)

--- a/Assets/Scripts/Network/ReplayableTCPClient.cs
+++ b/Assets/Scripts/Network/ReplayableTCPClient.cs
@@ -29,10 +29,6 @@ public abstract class ReplayableTCPClient<MESSAGE> : ReplayableClient
 	{
 		get{return client.LastError.Message; }
 	}
-	protected int LastErrorCode
-	{
-		get{return client.LastError.ErrorCode; }
-	}
 	protected long LastSeen
 	{
 		get{return client.LastSeen; }

--- a/Assets/Scripts/Network/TCPClient.cs
+++ b/Assets/Scripts/Network/TCPClient.cs
@@ -57,7 +57,7 @@ public class TCPClient<MESSAGE>
 
 	public TCPClientState State { get; private set; }
 
-	public SocketException LastError { get; private set; }
+	public Exception LastError { get; private set; }
 
 	public TCPClient(string host, int port)
 	{
@@ -217,10 +217,13 @@ public class TCPClient<MESSAGE>
 				dumpWriter.Write (outMemoryStream.GetBuffer(), 0, packet_length);
 			
 		}
-		catch(SocketException exc)
+		catch(Exception exc)
 		{
 			State = TCPClientState.Idle;
-			LastError = exc;
+			if (exc.InnerException != null)
+				LastError = exc.InnerException;
+			else
+				LastError = exc;
 		}
 	}
 


### PR DESCRIPTION
Correctly catch Exception when NetwrokStream write fails.
It is thrown as IOException with InnerException as SocketException so
catch exception and check the inner exception for socket error details