### PR TITLE
fix Extension methods requires `System.Runtime.CompilerSerices.ExtensionAttribute'

### DIFF
--- a/Assets/Scripts/UI/UISetExtensions.cs
+++ b/Assets/Scripts/UI/UISetExtensions.cs
@@ -2,6 +2,13 @@
 using UnityEngine.UI;
 using System.Reflection;
 
+//fix for unity Extension methods requires `System.Runtime.CompilerServices.ExtensionAttribute'
+//see http://schoening.it/blog/solution-cannot-define-a-new-extension-method-because-the-compiler-required-type-system-runtime-compilerservices-extensionattribute-cannot-be-found-are-you-missing-a-reference-to-system-core-dll/
+namespace System.Runtime.CompilerServices
+{
+	public class ExtensionAttribute : Attribute { }
+}
+
 public static class UISetExtensions
 {
 	static MethodInfo toggleSetMethod;


### PR DESCRIPTION
This will emit warning in some circumstances but not an error (as without on .Net 2.0)

See http://www.danielmoth.com/Blog/Using-Extension-Methods-In-Fx-20-Projects.aspx for explanation